### PR TITLE
add prop:not-racket-syntax

### DIFF
--- a/syntax-category.rkt
+++ b/syntax-category.rkt
@@ -1,0 +1,11 @@
+#lang racket/base
+
+(provide prop:not-racket-syntax
+         not-racket-syntax?)
+
+; Used to indicate that a value in the expander environment should not be used as racket syntax,
+; even though it may implement prop:procedure. In this case, prop:procedure is only used to raise a syntax
+; error when used in a racket expression.
+(define-values
+  (prop:not-racket-syntax not-racket-syntax? not-racket-syntax-ref)
+  (make-struct-type-property 'not-racket-syntax))


### PR DESCRIPTION
When defining syntax that shouldn't be used as a racket expression, we do something like

```racket
(define-syntax foo (lambda (stx) (raise-syntax-error #f "not a racket expression" stx)))
```

But then, if you have some value in the expander environment, you don't know if it's a regular racket macro, or one of these special values that racket thinks is a macro, but actually shouldn't be used as a racket expression. So we create a structure type property to indicate that a value is not meant to be used as racket syntax.